### PR TITLE
Update package references and copyright info

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 /**
- * Copyright IBM Corporation 2016, 2017
+ * Copyright IBM Corporation and the Kitura project authors 2016-2020
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Package@swift-3.swift
+++ b/Package@swift-3.swift
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corporation 2016, 2017
+ * Copyright IBM Corporation and the Kitura project authors 2016-2020
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Package@swift-4.0.swift
+++ b/Package@swift-4.0.swift
@@ -2,7 +2,7 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 /**
- * Copyright IBM Corporation 2016, 2017
+ * Copyright IBM Corporation and the Kitura project authors 2016-2020
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Package@swift-4.1.swift
+++ b/Package@swift-4.1.swift
@@ -2,7 +2,7 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 /**
- * Copyright IBM Corporation 2016, 2017
+ * Copyright IBM Corporation and the Kitura project authors 2016-2020
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Swift module maps for [zlib](https://www.zlib.net/), which allow you to use the 
 
 #### Add dependencies
 
-Add the `CZlib` package to the dependencies within your application’s `Package.swift` file. Substitute `"x.x.x"` with the latest `CZlib` [release](https://github.com/IBM-Swift/CZlib/releases).
+Add the `CZlib` package to the dependencies within your application’s `Package.swift` file. Substitute `"x.x.x"` with the latest `CZlib` [release](https://github.com/Kitura/CZlib/releases).
 
 ```swift
-.package(url: "https://github.com/IBM-Swift/CZlib.git", from: "x.x.x")
+.package(url: "https://github.com/Kitura/CZlib.git", from: "x.x.x")
 ```
 
 Add `CZlib` to your target's dependencies:

--- a/module.modulemap
+++ b/module.modulemap
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corporation 2016
+ * Copyright IBM Corporation and the Kitura project authors 2016-2020
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shim.h
+++ b/shim.h
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corporation 2016
+ * Copyright IBM Corporation and the Kitura project authors 2016-2020
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Update package references from IBM-Swift to Kitura wherever applicable, in addition to updating the copyright info wherever applicable as well.